### PR TITLE
edit the conf file to switch to http and use run insted of get_secret

### DIFF
--- a/helm/values/dev.yaml
+++ b/helm/values/dev.yaml
@@ -146,7 +146,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "scripts/get-secrets.sh","voice-indexer"]
+        command: ["bash", "run.sh","voice-indexer"]
         extraVars:
           ELASTIC_USER: "{{ .Values.config.elastic_user }}"
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
@@ -164,10 +164,10 @@ deployments:
             memory: "1024Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: /tmp/connections.json
+            mountPath: /hyperion-history-api/connections.json
             subPath: connections.json
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: /tmp/voice.config.json
+            mountPath: /hyperion-history-api/chains/voice.config.json
             subPath: voice.config.json
 
   voice-eos-hyperion-api:
@@ -212,7 +212,7 @@ deployments:
             name: hyperion-api
         image: "gcr.io/voice-dev-infra-services/voice/voice-eos-hyperion:{{ .Values.release.tag }}"
         imagePullPolicy: Always
-        command: ["bash", "scripts/get-secrets.sh","voice-api"]
+        command: ["bash", "run.sh","voice-api"]
         extraVars:
           ELASTIC_USER: "{{ .Values.config.elastic_user }}"
           ELASTIC_PASS: "{{ .Values.config.elastic_pass }}"
@@ -239,11 +239,11 @@ deployments:
             memory: "256Mi"
         volumeMounts:
           - name: eos-hyperion-connections
-            mountPath: /tmp/connections.json
+            mountPath: /hyperion-history-api/connections.json
             subPath: connections.json
             readOnly: false
           - name: "{{ if .Values.config.abi_scan }}eos-hyperion-config-abi{{ else }}eos-hyperion-config{{ end }}"
-            mountPath: /tmp/voice.config.json
+            mountPath: /hyperion-history-api/chains/voice.config.json
             subPath: voice.config.json
             readOnly: false
 hpas:
@@ -516,11 +516,12 @@ configmaps:
           vhost: voice
           frameMax: '0x10000'
         elasticsearch:
-          protocol: https
-          host: " "
+          protocol: http
+          host: elastic.service
           ingest_nodes:
-          user:
-          pass:
+            - elastic.service
+          user: ""
+          pass: ""
         redis:
           host: "172.31.32.12"
           port: '6379'


### PR DESCRIPTION
edited the helm file to use the old elastic cluster [dev] had to change it to static as the script that fills some of the data to the json files dose not work with empty strings,
this way the developers don't need to wait until the indexer finish the data reset in the elastic cloud